### PR TITLE
Remove fastify-jwt plugin registration from index.js

### DIFF
--- a/src/step-9-decorators/index.js
+++ b/src/step-9-decorators/index.js
@@ -11,9 +11,6 @@ function buildServer(config) {
 
   const fastify = Fastify(opts)
 
-  fastify.register(import('fastify-jwt'), {
-    secret: opts.JWT_SECRET,
-  })
   fastify.register(import('./routes/login.js'))
   fastify.register(import('./routes/users.js'))
 


### PR DESCRIPTION
On step-9-decorators, it is asked to create the authentication plugin and fastify-jwt is being registered in there. It is not necessary to be registered once again in index.js.