### PR TITLE
Use onRequest instead of preValidation hook

### DIFF
--- a/deck.md
+++ b/deck.md
@@ -1049,7 +1049,7 @@ class: branded
 
 - Create a `GET /` route in `routes/user/index.js`
 
-- Require authentication using the `preValidation` Fastify hook
+- Require authentication using the `onRequest` Fastify hook
 
 - Use the `fastify.authenticate` decorator
 
@@ -1077,7 +1077,7 @@ export default async function user(fastify) {
   fastify.get(
     '/user',
     {
-      preValidation: [fastify.authenticate],
+      onRequest: [fastify.authenticate],
       schema,
     },
     async req => req.user
@@ -1323,7 +1323,7 @@ const schema = {
 export default async function users(fastify) {
   fastify.get(
     '/',
-    { preValidation: [fastify.authenticate], schema },
+    { onRequest: [fastify.authenticate], schema },
     async () => {
       const { rows: users } = await fastify.pg.query(
         'SELECT id, username FROM users'

--- a/src/step-10-hooks/routes/user/index.js
+++ b/src/step-10-hooks/routes/user/index.js
@@ -10,7 +10,7 @@ export default async function user(fastify) {
   fastify.get(
     '/user',
     {
-      preValidation: [fastify.authenticate],
+      onRequest: [fastify.authenticate],
       schema,
     },
     async req => req.user

--- a/src/step-11-autoload/routes/user/index.js
+++ b/src/step-11-autoload/routes/user/index.js
@@ -10,7 +10,7 @@ export default async function user(fastify) {
   fastify.get(
     '/',
     {
-      preValidation: [fastify.authenticate],
+      onRequest: [fastify.authenticate],
       schema,
     },
     async req => req.user

--- a/src/step-12-database/routes/user/index.js
+++ b/src/step-12-database/routes/user/index.js
@@ -10,7 +10,7 @@ export default async function user(fastify) {
   fastify.get(
     '/',
     {
-      preValidation: [fastify.authenticate],
+      onRequest: [fastify.authenticate],
       schema,
     },
     async req => req.user

--- a/src/step-12-database/routes/users/index.js
+++ b/src/step-12-database/routes/users/index.js
@@ -13,7 +13,7 @@ const schema = {
 export default async function users(fastify) {
   fastify.get(
     '/',
-    { preValidation: [fastify.authenticate], schema },
+    { onRequest: [fastify.authenticate], schema },
     async (req) => {
       req.log.info('Users route called')
 

--- a/src/step-9-decorators/index.js
+++ b/src/step-9-decorators/index.js
@@ -11,9 +11,6 @@ function buildServer(config) {
 
   const fastify = Fastify(opts)
 
-  fastify.register(import('fastify-jwt'), {
-    secret: opts.JWT_SECRET,
-  })
   fastify.register(import('./routes/login.js'))
   fastify.register(import('./routes/users.js'))
 


### PR DESCRIPTION
Changed preValidation lifecycle hook to onRequest, to resolve #28.