### PR TITLE
fix: increased test specific timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@tsconfig/node16": "^1.0.3",
         "@types/http-errors": "^1.8.2",
-        "@types/node": "^18.7.16",
+        "@types/node": "^16.7.16",
         "@types/sinon": "^10.0.13",
         "@types/tap": "^15.0.7",
         "@typescript-eslint/eslint-plugin": "^5.36.2",
@@ -1274,9 +1274,9 @@
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
     },
     "node_modules/@types/node": {
-      "version": "18.7.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
-      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
+      "version": "16.11.59",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.59.tgz",
+      "integrity": "sha512-6u+36Dj3aDzhfBVUf/mfmc92OEdzQ2kx2jcXGdigfl70E/neV21ZHE6UCz4MDzTRcVqGAM27fk+DLXvyDsn3Jw==",
       "dev": true
     },
     "node_modules/@types/sinon": {
@@ -12957,9 +12957,9 @@
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
     },
     "@types/node": {
-      "version": "18.7.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
-      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
+      "version": "16.11.59",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.59.tgz",
+      "integrity": "sha512-6u+36Dj3aDzhfBVUf/mfmc92OEdzQ2kx2jcXGdigfl70E/neV21ZHE6UCz4MDzTRcVqGAM27fk+DLXvyDsn3Jw==",
       "dev": true
     },
     "@types/sinon": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@tsconfig/node16": "^1.0.3",
     "@types/http-errors": "^1.8.2",
-    "@types/node": "^18.7.16",
+    "@types/node": "^16.7.16",
     "@types/sinon": "^10.0.13",
     "@types/tap": "^15.0.7",
     "@typescript-eslint/eslint-plugin": "^5.36.2",


### PR DESCRIPTION
It seems the problem started when dependabot bumped the @node/types version to 18.7.16 while we are using node 16 and this causes some internal problems
It's very hard to identify what cause the problem because the [@node/types](https://github.com/DefinitelyTyped/DefinitelyTyped) library doesn't have a proper changelog
resolves: https://github.com/nearform/the-fastify-workshop/issues/598