### PR TITLE
chore: fix wording

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -554,7 +554,7 @@ http://localhost:3000/login
 
 # Step 5 Constraints
 
-- Route validation can also be constrained to match properties of the request. By default fastify supports `version` (via `Accept-Version` header) and `host` (via `Host` header)
+- Route matching can also be constrained to match properties of the request. By default fastify supports `version` (via `Accept-Version` header) and `host` (via `Host` header)
 
 > 🏆 Custom constraints can be added via [`find-my-way`](https://github.com/delvedor/find-my-way)
 


### PR DESCRIPTION
I think the `validation` wording could be confusing because constraints are used during the request's routing to the right handler.

Moreover, do you think it is worth adding this link?

https://github.com/Eomm/header-constraint-strategy

It is a plugin I did to ease the constraint creation - because it is a bit cumbersome doing it manually