### PR TITLE
Step 5 solution typo

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -583,7 +583,7 @@ https://www.fastify.io/docs/latest/Reference/Routes/#constraints
 export default async function version(fastify) {
   fastify.route({ 
     method: 'GET',
-    url: '/verion',
+    url: '/version',
     constraints: { version: '1.0.0' },
     handler: async (req) => {
       return { version: '1.0.0' }


### PR DESCRIPTION
**Description**

The Fastify route URL was misspelled in the step 5 solution slide `/verion => /version`. It is correct in the solution code.

<img width="1000" alt="fastify-workshop-step-5-typo" src="https://user-images.githubusercontent.com/121885756/211930362-8c1f1be3-ebdb-4839-b9d5-cb2a5b44b475.png">
