### PR TITLE
chore: ensure docker compose commands works for new versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "build": "slidev build",
     "start": "slidev --open",
     "export": "slidev export",
-    "db:up": "docker-compose up -d",
+    "db:up": "docker compose up -d",
     "db:migrate": "postgrator",
-    "db:down": "docker-compose down",
+    "db:down": "docker compose down",
     "lint": "eslint --ext .ts,.js ./src",
     "test": "cross-env TS_NODE_FILES=1 c8 tap --no-cov -j1 --ts"
   },


### PR DESCRIPTION
Problem fixed:  
- In the new versions of Docker Compose the alias command no longer uses the "-" character. Because of it the commands "npm run dp:up" and "npm run db:migrate" was failing. 

Reference to make the change:
https://github.com/docker/compose#docker-compose-v2