### PR TITLE
made slide container scrollable if there's offset

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -52,5 +52,9 @@ ol {
 }
 
 .slidev-layout {
+  display: flex;
+  flex-direction: column;
+}
+.slidev-code-wrapper {
   overflow-y: auto;
 }

--- a/styles.css
+++ b/styles.css
@@ -50,3 +50,7 @@ ol {
 #slide-shapes-transitions-image img {
   height: 25rem;
 }
+
+.slidev-layout {
+  overflow-y: auto;
+}


### PR DESCRIPTION
Closes https://github.com/nearform/the-fastify-workshop/issues/1034

Made slides scrollable by setting `overflow-y: auto` on slide container.

Before:
![Screenshot 2023-08-15 at 17 21 36](https://github.com/nearform/the-fastify-workshop/assets/141126446/d25f9d77-107b-43a1-9dbb-45d27cac63ff)


After:
![Screenshot 2023-08-15 at 17 20 10](https://github.com/nearform/the-fastify-workshop/assets/141126446/8eac7848-105b-4137-af69-f79fd1d79799)
![Screenshot 2023-08-15 at 17 20 23](https://github.com/nearform/the-fastify-workshop/assets/141126446/46edc3dc-5098-4d1d-b67f-b027ec06e665)
