### PR TITLE
refactor: migrate away from usage of deprecated Type.Strict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fastify/jwt": "^8.0.1",
         "@fastify/postgres": "^5.2.0",
         "@nearform/sql": "^1.10.5",
-        "@sinclair/typebox": "^0.33.12",
+        "@sinclair/typebox": "^0.33.17",
         "@slidev/cli": "^0.49.29",
         "@vueuse/shared": "^11.0.3",
         "desm": "^1.3.0",
@@ -1814,9 +1814,10 @@
       "integrity": "sha512-5FinaOp6Vdh/dl4/yaOTh0ZeKch+rYS8DUb38V3GMKYVkdqzxw53lViRKUYkVILRiVQT7dcPC7VvAKOR73zVtQ=="
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.33.12",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.12.tgz",
-      "integrity": "sha512-d5KrXIdPolLp8VpGpZAQvEz8ioVtFlUQSyCIS2sEBi7FKhceIB7nj9BlNfqqvp5wmOfg8v8bP1rAvYYkjz21/Q=="
+      "version": "0.33.17",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.17.tgz",
+      "integrity": "sha512-75232GRx3wp3P7NP+yc4nRK3XUAnaQShxTAzapgmQrgs0QvSq0/mOJGoZXRpH15cFCKyys+4laCPbBselqJ5Ag==",
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@fastify/jwt": "^8.0.1",
     "@fastify/postgres": "^5.2.0",
     "@nearform/sql": "^1.10.5",
-    "@sinclair/typebox": "^0.33.12",
+    "@sinclair/typebox": "^0.33.17",
     "@slidev/cli": "^0.49.29",
     "@vueuse/shared": "^11.0.3",
     "desm": "^1.3.0",

--- a/slides.md
+++ b/slides.md
@@ -1440,20 +1440,17 @@ import { Type, Static } from '@sinclair/typebox'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 import errors from 'http-errors'
 
-const BodySchema = Type.Strict(
-  Type.Object({
-    username: Type.String(),
-    password: Type.String(),
-  })
-)
+const BodySchema = Type.Object({
+  username: Type.String(),
+  password: Type.String(),
+})
+
 // Generate type from JSON Schema
 type BodySchema = Static<typeof BodySchema>
 
-const ResponseSchema = Type.Strict(
-  Type.Object({
-    token: Type.String(),
-  })
-)
+const ResponseSchema = Type.Object({
+  token: Type.String(),
+})
 type ResponseSchema = Static<typeof ResponseSchema>
 
 const schema = {

--- a/src/step-14-typescript/routes/login.ts
+++ b/src/step-14-typescript/routes/login.ts
@@ -2,20 +2,16 @@ import { Type, Static } from '@sinclair/typebox'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 import errors from 'http-errors'
 
-const BodySchema = Type.Strict(
-  Type.Object({
-    username: Type.String(),
-    password: Type.String(),
-  }),
-)
+const BodySchema = Type.Object({
+  username: Type.String(),
+  password: Type.String(),
+})
 
 type BodySchema = Static<typeof BodySchema>
 
-const ResponseSchema = Type.Strict(
-  Type.Object({
-    token: Type.String(),
-  }),
-)
+const ResponseSchema = Type.Object({
+  token: Type.String(),
+})
 
 type ResponseSchema = Static<typeof ResponseSchema>
 

--- a/src/step-14-typescript/routes/users.ts
+++ b/src/step-14-typescript/routes/users.ts
@@ -1,12 +1,10 @@
 import { Static, Type } from '@sinclair/typebox'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 
-const ResponseSchema = Type.Strict(
-  Type.Array(
-    Type.Object({
-      username: Type.String(),
-    }),
-  ),
+const ResponseSchema = Type.Array(
+  Type.Object({
+    username: Type.String(),
+  }),
 )
 
 type ResponseSchema = Static<typeof ResponseSchema>


### PR DESCRIPTION
Closes #1300 

* Type.Scrict appeared to be deprecated, so this migrates away from its usage
* update @sinclair/typebox to latest

Do check that my assumption here is correct, though, I don't _think_ the Type.Strict was doing anything special? 

![Screenshot 2024-10-24 at 09 29 06](https://github.com/user-attachments/assets/4ebea857-164b-440e-ba9a-82bc587f3252)
