### PR TITLE
Remove unused tap code

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,5 @@
     "sinon": "^19.0.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.7.3"
-  },
-  "tap": {
-    "node-arg": [
-      "--no-warnings"
-    ]
   }
 }


### PR DESCRIPTION
Closes #1358
The package.json file still had references to tap even after it was removed.