### PR TITLE
fix(ts): make `tsc --noEmit` clean and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           node-version-file: .nvmrc
       - run: npm ci
       - run: npm run db:migrate
+      - run: npm run typecheck
       - run: npm test
 
   automerge:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           npm ci
           npm run db:migrate
           npm run lint
+          npm run typecheck
           npm test
 
   build_windows:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:migrate": "postgrator",
     "db:down": "docker compose down",
     "lint": "eslint ./src",
-    "test": "c8 --check-coverage --100 node --test \"src/**/test/**/*.test.js\""
+    "test": "c8 --check-coverage --100 node --test \"src/**/test/**/*.test.js\"",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@fastify/autoload": "^6.3.1",

--- a/src/step-14-typescript/test/login.test.ts
+++ b/src/step-14-typescript/test/login.test.ts
@@ -6,10 +6,17 @@ import sinon from 'sinon'
 
 import loginRoute from '../routes/login'
 
+// The `jwt` decorator type, as Fastify sees it once `@fastify/jwt` is registered.
+type Jwt = FastifyInstance['jwt']
+
 function buildServer(): FastifyInstance {
-  return fastify()
-    .decorate('jwt', { sign: sinon.stub() })
-    .register(loginRoute)
+  // These tests only exercise `sign`, so stub just that. Typing the stub against
+  // the real signature keeps its arguments checked; the assertion then widens only
+  // the container, since a one-key object can't satisfy all of `Jwt`.
+  const sign = sinon.stub<Parameters<Jwt['sign']>, string>()
+  const jwt = { sign } as unknown as Jwt
+
+  return fastify().decorate('jwt', jwt).register(loginRoute)
 }
 
 test('POST /login', async t => {

--- a/src/step-14-typescript/test/login.test.ts
+++ b/src/step-14-typescript/test/login.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
+import { SignOptions, SignPayloadType } from '@fastify/jwt'
 import fastify, { FastifyInstance } from 'fastify'
 import sinon from 'sinon'
 
@@ -10,10 +11,17 @@ import loginRoute from '../routes/login'
 type Jwt = FastifyInstance['jwt']
 
 function buildServer(): FastifyInstance {
-  // These tests only exercise `sign`, so stub just that. Typing the stub against
-  // the real signature keeps its arguments checked; the assertion then widens only
-  // the container, since a one-key object can't satisfy all of `Jwt`.
-  const sign = sinon.stub<Parameters<Jwt['sign']>, string>()
+  // These tests only exercise `sign`, so stub just that, typed to the one overload
+  // the route uses: `sign(payload)` returning the token. `Parameters<Jwt['sign']>`
+  // would look tidier but resolves to the *last* of `sign`'s three overloads — the
+  // callback one, which returns `void` — so the stub would reject the single-argument
+  // call in `routes/login.ts`.
+  const sign = sinon
+    .stub<[SignPayloadType, Partial<SignOptions>?], string>()
+    .returns('jwt token')
+
+  // A single-signature stub can't satisfy all three overloads, so an assertion is
+  // unavoidable. Keep it on the container only: `sign`'s own arguments stay checked.
   const jwt = { sign } as unknown as Jwt
 
   return fastify().decorate('jwt', jwt).register(loginRoute)
@@ -62,8 +70,6 @@ test('POST /login', async t => {
 
   await t.test('obtains a token with right credentials', async () => {
     const app = buildServer()
-
-    app.jwt.sign = sinon.stub().returns('jwt token')
 
     const res = await app.inject({
       url: '/login',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
+  // This config typechecks the Node examples under `src/`. `include` is left at its
+  // default so any new `.ts` is gated automatically. Slidev-layer `.ts` (anything
+  // importing `.vue` or `~icons/*`) can't compile under `node16` resolution and
+  // belongs in this list rather than being "fixed" — Vite builds it without
+  // typechecking. `components.d.ts` is generated and pulls in `@slidev/client`.
   "exclude": ["node_modules", "components.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json"
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "exclude": ["node_modules", "components.d.ts"]
 }


### PR DESCRIPTION
`npx tsc --noEmit` reported **5 errors on `master`**. Nothing in the pipeline runs it, so
they were latent rather than breaking anything — surfaced while verifying #1551.

Still true on current `master` (eslint 9 flat config, typescript 5.9.2, `@fastify/jwt` 10):
the same five errors, including the identical TS2322.

## Cause 1 — 4 errors inside `node_modules/@slidev/client`

```
node_modules/@slidev/client/builtin/VClick.ts(9,28): error TS2835: Relative import paths need explicit file extensions ...
node_modules/@slidev/client/builtin/VClicks.ts(11,23): error TS2307: Cannot find module './VClickGap.vue' ...
```

The generated `components.d.ts` references those files directly:

```ts
VClick: typeof import('./node_modules/@slidev/client/builtin/VClick.ts')['default']
```

That pulls them into the program, and under this tsconfig's `node16` module resolution
their own extensionless relative imports are errors.

The root cause is a config mismatch: `tsconfig.json` extends `@tsconfig/node18` and
exists for the **step-14 Node code**. It can never successfully typecheck the
Vue/Slidev layer, which needs bundler resolution plus `.vue` and `~icons/*` aliases.

**Fix** — exclude the one generated file that pulls that layer in:

```json
"exclude": ["node_modules", "components.d.ts"]
```

`include` stays at its default, so the gate covers the whole repo and any future `.ts`
is picked up automatically. Nothing is lost: Slidev files are still built by Vite
(which doesn't typecheck them), `components.d.ts` is regenerated by
`unplugin-vue-components`, and `components/Copyright.ts` remains typechecked.
`skipLibCheck` was already `true` but doesn't help here — these are `.ts` sources, not
`.d.ts`.

## Cause 2 — a real error in the repo's own code

```
src/step-14-typescript/test/login.test.ts(11,24): error TS2322:
  Type 'SinonStub<...>' is not assignable to type '{ (payload, options?): string; ... }'
```

`decorate('jwt', { sign: sinon.stub() })` can't satisfy the `jwt` decorator type, and
the reason is narrower than it looks. The decorator target contextually types the bare
`sinon.stub()`, and contextual inference against an overloaded type picks the **last**
overload — `sign(payload, options, callback): void`. So the stub comes out as
`SinonStub<[payload, options, callback], void>`, which then satisfies none of the three
signatures. That single mismatch on `sign` is the whole error; the missing `options`,
`verify`, `decode` and `lookupToken` are never reported.

The same trap catches `Parameters<Jwt['sign']>`, which resolves to that same callback
overload — so the stub would be a mandatory three-argument function returning `string`,
rejecting the one-argument `sign({ username })` that `routes/login.ts:38` actually makes.
The stub is typed to the overload in use instead:

```ts
type Jwt = FastifyInstance['jwt']

const sign = sinon
  .stub<[SignPayloadType, Partial<SignOptions>?], string>()
  .returns('jwt token')

const jwt = { sign } as unknown as Jwt

return fastify().decorate('jwt', jwt).register(loginRoute)
```

A single-signature stub can't satisfy all three overloads, so the container assertion is
unavoidable — but it stays on the container only, and the stub's own arguments are
genuinely checked: `sign()`, a non-`SignOptions` second argument, and using the result as
a number are all compile errors, while both real call shapes pass.

The stub also gets its return value at creation, so the typed stub is the one the
'obtains a token' subtest exercises rather than being replaced there by a bare
`sinon.stub()` — previously the only subtest reaching `sign` was the one where the typing
did not apply.

## Enforcement

Added a `typecheck` script (`tsc --noEmit`) and wired it into **both** `build_linux` and
`build_windows`. An unenforced check is exactly how these errors accumulated in the first
place, and both jobs are required by `automerge` — gating only one of them would leave
half the matrix able to go green with a broken `.ts`.

Worth noting how much this gate carries: root `npm test` globs
`src/**/test/**/*.test.js`, so `login.test.ts` is never run by the suite — `typecheck`
is the only CI coverage the step-14 TypeScript example has.

## Verification

Re-run at this head on **current `master`'s dependency set** (rebased onto `20648f8`):

- `npm run typecheck`: ✅ 0 errors (`master` alone: 5)
- `npm run lint`: ✅
- `npm run build` (`slidev build`): ✅
- root `npm test`: ✅ 90/90, 100% coverage
- step-14's own `ts-node` test script: ✅ 12/12, 100% coverage

Also confirmed the deny-list actually gates: a deliberately broken `.ts` placed at the
repo root and under `src/step-01-hello-world/` is caught by `npm run typecheck`, where
the earlier `include` allow-list reported 0 errors for both.


