### PR TITLE
chore(deps): consolidate open Dependabot updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,8 @@
         "@types/http-errors": "^2.0.5",
         "@types/node": "^26.2.0",
         "@types/sinon": "^17.0.4",
-        "@typescript-eslint/eslint-plugin": "^8.46.2",
-        "@typescript-eslint/parser": "^8.46.2",
+        "@typescript-eslint/eslint-plugin": "^8.58.0",
+        "@typescript-eslint/parser": "^8.58.0",
         "c8": "^10.1.3",
         "cross-env": "^10.1.0",
         "eslint": "^9.38.0",
@@ -48,7 +48,7 @@
         "prettier": "^3.5.1",
         "sinon": "^21.0.0",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^5.9.2"
+        "typescript": "~6.0.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3524,19 +3524,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/@slidev/cli/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@slidev/cli/node_modules/vite": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
@@ -3906,19 +3893,6 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@slidev/client/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@slidev/client/node_modules/vue-router": {
@@ -15516,9 +15490,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "@types/http-errors": "^2.0.5",
     "@types/node": "^26.2.0",
     "@types/sinon": "^17.0.4",
-    "@typescript-eslint/eslint-plugin": "^8.46.2",
-    "@typescript-eslint/parser": "^8.46.2",
+    "@typescript-eslint/eslint-plugin": "^8.58.0",
+    "@typescript-eslint/parser": "^8.58.0",
     "c8": "^10.1.3",
     "cross-env": "^10.1.0",
     "eslint": "^9.38.0",
@@ -55,6 +55,6 @@
     "prettier": "^3.5.1",
     "sinon": "^21.0.0",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.9.2"
+    "typescript": "~6.0.3"
   }
 }

--- a/src/step-14-typescript/tsconfig.json
+++ b/src/step-14-typescript/tsconfig.json
@@ -5,5 +5,10 @@
   },
   "compilerOptions": {
     "esModuleInterop": true,
+    // TypeScript 6 raises TS5011 unless `rootDir` is
+    // explicit: this step's scripts hand ts-node only
+    // `./test/*.test.ts` or only `server.ts`, so it
+    // infers `./test` / `./routes` as the common root.
+    "rootDir": ".",
   },
 }


### PR DESCRIPTION
Consolidates the open Dependabot PRs into one reviewable change. The lockfile was updated
**in place** with `npm install` (never deleted and recreated), so `lockfileVersion` stays 3
and no `resolved`/`integrity` fields were stripped.

Closes #1578

## Summary

Two Dependabot PRs were open. Neither could be folded in as-is:

| PR | Package | Dependabot target | Outcome |
|----|---------|-------------------|---------|
| #1577 | `typescript` | 5.9.2 → 7.0.2 | **partially folded** — landed at 6.0.3, the highest version that installs. PR left open. |
| #1565 | `bn.js` | 4.12.1 → 4.12.5 | **nothing to fold** — `master` is already on 4.12.5. Closed as obsolete. |

The whole change is three declared-range lines plus one config line:

| File | Change |
|---|---|
| `package.json` | `typescript` `^5.9.2` → `~6.0.3` |
| `package.json` | `@typescript-eslint/{eslint-plugin,parser}` `^8.46.2` → `^8.58.0` — declared floor only, **moves no package** |
| `package-lock.json` | 4 touched entries, `+6 / −32` lines |
| `src/step-14-typescript/tsconfig.json` | `+ "rootDir": "."` |

### Why 6.0.3 and not Dependabot's 7.0.2

TypeScript 7 does not install here. #1577 has been red since it opened and the failing step is
`npm ci` itself —
[build_linux on run 32704914946](https://github.com/nearform/the-fastify-workshop/actions/runs/32704914946/job/97363836624):

```
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error While resolving: @typescript-eslint/eslint-plugin@8.67.0
npm error Found: typescript@7.0.2
npm error   dev typescript@"^7.0.2" from the root project
npm error   peer typescript@">=5.5.0" from @shikijs/twoslash@4.4.3
npm error   6 more (@typescript/ata, @typescript/vfs, ts-api-utils, ts-node, ...)
npm error
npm error Could not resolve dependency:
npm error peer typescript@">=4.8.4 <6.1.0" from @typescript-eslint/eslint-plugin@8.67.0
npm error
npm error Conflicting peer dependency: typescript@6.0.3
```

npm names the ceiling itself on that last line: **6.0.3**.

This is not fixable by bumping `@typescript-eslint` forward. Checked against the registry:

- `@typescript-eslint/eslint-plugin@latest` = **8.68.0**, peer `typescript ">=4.8.4 <6.1.0"`.
- `@typescript-eslint/eslint-plugin@canary` = **8.68.1-alpha.6**, peer `typescript ">=4.8.4 <6.1.0"`.
- No 9.x line is published, and no dist-tag points at anything with a wider `typescript` peer.
  The umbrella `typescript-eslint@8.68.0` declares the same `<6.1.0`.

Nor by letting npm resolve loosely. Reproduced from a clean `git archive master` tree with only
`typescript` changed to `^7.0.2`, matching #1577 exactly:

| | result |
|---|---|
| `npm ci` (base lockfile) | ✗ `EUSAGE` — lockfile out of sync, as expected |
| `npm install --package-lock-only` | ✓ rc=0, but with **15** `npm warn ERESOLVE overriding peer dependency` lines |
| `npm ci` **from the lockfile npm just wrote** | ✗ `ERESOLVE` — byte-for-byte the CI failure above |

So there is no lockfile state in which TypeScript 7 survives `npm ci` — which is what both CI
legs run — short of *downgrading* `@typescript-eslint` to a pre-8.18 release, where the
`typescript` peer is declared optional with no range at all. That is not a real option: it means
an older linter with no TypeScript 7 AST support. Forcing it instead with `overrides` or
`--legacy-peer-deps` would mean committing a knowingly-violated peer range into a teaching repo,
and would turn `npm ls --all` red with a *new* finding on top of the pre-existing ones.

`typescript-eslint` is load-bearing here, not incidental: `eslint.config.js` uses
`@typescript-eslint/parser` as the parser for **all** of `['**/*.js', '**/*.ts']` — so removing
it changes how every `.js` file in the repo is parsed — and spreads
`tsPlugin.configs['flat/recommended']` as a whole rule set.

6.0.3 is also a version the repo's own tree already wanted: `@slidev/cli@52.19.0` and
`@slidev/client@52.19.0` each declare `"typescript": "^6.0.3"` as a hard `dependencies` entry.
`master` consequently installs **three** copies of the compiler — root 5.9.2 plus two nested
6.0.3. Aligning the root collapses them to one, which is the entire lockfile diff.

**#1577 is left open**, not closed: the 6 → 7 step is still wanted, just unavailable upstream, so
it stays as the tracker. It cannot self-merge in the meantime — `build_linux` and `build_windows`
are both FAILURE on that branch, so the `automerge` job's `needs:` is never satisfied
(`automerge: skipped`, `mergeStateStatus: BLOCKED`).

### Why `~6.0.3` and not `^6.0.3`

`^6.0.3` would permit 6.1.x, which every published `@typescript-eslint` rejects (`<6.1.0`, right
up to `canary`). That is a declared range whose upper half this tree cannot satisfy, and a plain
`npm install` after a hypothetical 6.1 release would walk straight into the `ERESOLVE` above.
`~6.0.3` still admits 6.0.4+ patches and loses nothing real: stable 6.x is only 6.0.2 and 6.0.3,
and TypeScript's `latest` is already 7.0.2 with `next` on `7.1.0-dev.*`. This is a deliberate
departure from the repo's otherwise-uniform `^`; happy to switch back if reviewers disagree.

### Why the `@typescript-eslint` floor moves — with no package movement

The declared floor `^8.46.2` **rejects** TypeScript 6:

```
@typescript-eslint/eslint-plugin@8.46.2  peer typescript ">=4.8.4 <6.0.0"
@typescript-eslint/eslint-plugin@8.58.0  peer typescript ">=4.8.4 <6.1.0"   <- first release that accepts 6.x
```

Leaving it at `^8.46.2` would ship a `package.json` whose declared devDependency set has no
solution at the low end of its own range — demonstrable with an explicit install:

```
$ npm install --package-lock-only -D @typescript-eslint/{eslint-plugin,parser}@8.46.2
npm error code ERESOLVE
npm error Found: typescript@6.0.3
npm error   dev typescript@"~6.0.3" from the root project
npm error Could not resolve dependency:
npm error peer typescript@">=4.8.4 <6.0.0" from @typescript-eslint/parser@8.46.2
```

Raising the floor to `^8.58.0` fixes that and **moves nothing**: npm resolves max-satisfying and
the lockfile already sat at 8.67.0, which satisfies both `^8.46.2` and `^8.58.0`. Confirmed —
`@typescript-eslint` does not appear anywhere in the lockfile diff, and `8.67.0` is still what
installs. An earlier draft of this PR bumped these to `^8.68.0`; that was dropped, because it
moved ten lockfile entries for no reason. `^8.58.0` is the minimum that makes the manifest
coherent.

### `src/step-14-typescript/tsconfig.json` — `"rootDir": "."`

TypeScript 6 raises `TS5011` when it has to infer the common source directory, and step 14's own
scripts hand `ts-node` a narrow file set, so **both** of them hit it:

```
$ npm test    # npx c8 node --test -r ts-node/register ./test/*.test.ts
error TS5011: The common source directory of 'tsconfig.json' is './test'.
  The 'rootDir' setting must be explicitly set to this or another path …

$ npm start   # ts-node-dev --project ./tsconfig.json server.ts
error TS5011: The common source directory of 'tsconfig.json' is './routes'.
```

All 12 of the step's tests pass on `master` under 5.9.2 and all 12 fail to compile under 6.0.3
without this line. `"noEmit": true`, `"include": ["."]`, `"outDir": "./dist"` and
`ts-node: { files: true }` were each tried instead and each still fails TS5011; `"rootDir"` is
the fix TypeScript's own message asks for.

The change is contained: the root `npm run typecheck` reads only the root `tsconfig.json` (which
reports `rootDir = None`) and is unaffected, `npm run lint` sets no `parserOptions.project` so it
never reads this file and never lints JSON anyway, `"."` is relative so there is no Windows
exposure, and `src/step-14-typescript` is the only workspace with either a `tsconfig.json` or a
`ts-node` script.

**Neither CI leg would have caught the breakage.** The root `test` script globs
`src/**/test/**/*.test.js` — `.js` only — so step 14's four `.test.ts` files are never *executed*
by CI, on either platform. They were run by hand for this PR. They are still *type-checked*: the
root `tsconfig.json` has no `include`, so `tsc --noEmit` picks up all 11 of step 14's `.ts` files
including the four test files — which is precisely why this PR needs no source changes there.
Widening the test glob so the step is actually exercised is out of scope for a dependency bump,
but worth a follow-up.

## Verification

Linux, Node **24.20.0** / npm **11.19.0** — `.nvmrc` is `lts/*`, which is what
`actions/setup-node` resolves in CI. PostgreSQL 18 in a container for the step-13 integration
tests. Every row was run on a clean `master` checkout **and** on this branch.

| Step | In CI? | `master` | This branch |
|---|---|---|---|
| `npm ci` | both legs | ✅ | ✅ (and leaves the lockfile untouched) |
| `npm run db:migrate` | both legs | ✅ | ✅ |
| `npm run lint` | linux | ✅ | ✅ |
| `npm run typecheck` | both legs | ✅ | ✅ |
| `npm test` | both legs | ✅ 90/90, 100% coverage | ✅ 90/90, 100% coverage |
| `npm run build` (slidev) | deploy only | ✅ 132 files / 2,465,248 B | ✅ **all 132 sha256-identical** |
| `npm run build -- --base /the-fastify-workshop/` | deploy only | ✅ | ✅ **all 132 sha256-identical** |
| `npm ls --all` | no | ⚠️ exit 1 | ⚠️ exit 1 — **identical** findings |
| `npm audit` | no | 15 (6 low / 3 mod / 6 high) | **identical, package by package** |
| `src/step-14-typescript` `npm test` | **no** | ✅ 12/12 | ✅ 12/12 |
| `src/step-14-typescript` `npm start` | **no** | — | ✅ `Server listening at http://[::1]:3000` |

`build_windows` has no local equivalent and is covered only by CI. Nothing here is
platform-sensitive: `"rootDir": "."` is relative, and `typescript@6.0.3` declares no
`os`/`cpu`/`optionalDependencies`, so the bump carries no platform-specific payload.

Beyond exit codes:

- **The lockfile diff is 4 touched entries and nothing else**: root `typescript` 5.9.2 → 6.0.3,
  the two now-redundant `@slidev/*/node_modules/typescript@6.0.3` copies removed, and the root
  `""` entry's `devDependencies` mirror. `+6 / −32` lines. `lockfileVersion` stays 3. Entries
  carrying `resolved` go 1056 → 1054 and `integrity` 1041 → 1039 — exactly the two removals, and
  **zero surviving entries lost either field**. Nothing was nested or pruned; `@typescript-eslint`
  does not move.
- **Control install.** `npm install` on an unmodified `master` checkout with the same
  npm 11.19.0 leaves `package-lock.json` **byte-identical**, so none of the diff is
  npm-version churn.
- **The toolchain still fires under 6.0.3 — it is not silently no-oping.** A throwaway bad file
  (written, checked, deleted, never committed) makes `tsc` report `TS2322` and `eslint` report
  three `@typescript-eslint/no-unused-vars` plus one `@typescript-eslint/no-explicit-any`. Both
  the TypeScript parser and the plugin are live on the new compiler.
- **The server actually boots.** Neither CI leg starts a server, so step 14's Fastify instance
  was started by hand under `ts-node-dev` on 6.0.3; it logs `Fastify is starting up!` and
  `Server listening`. Its 12 tests additionally exercise `@fastify/jwt` registration through
  `fastify.inject`.
- **The slides build was checked both ways, because PR CI never runs it at all.** `npm run build`
  only runs in `deploy.yml` on push to `master`, so a regression would land on gh-pages
  unreviewed. The compiler genuinely does move for that chain — `twoslash`,
  `@shikijs/twoslash`, `@typescript/ata`, `@typescript/vfs` and `ts-api-utils` all resolve the
  **root** `typescript` — and the output is nevertheless identical: **all 132 files match by
  sha256** on both the plain build and the `--base /the-fastify-workshop/` build that `deploy.yml`
  actually invokes.
- **No advisory movement in either direction.** `npm audit --package-lock-only` on the base and
  branch lockfiles reports the same 15 advisories over the same 15 packages with the same
  affected ranges — nothing entered a vulnerable range and nothing left one. The only delta in
  the whole report is `metadata.dependencies.prod` 814 → 812, the two removed compiler copies.
  `typescript` appears in no advisory.

### `npm ls --all` (pre-existing, unchanged)

Exit 1 on both sides, with the same 11 lines covering the same two packages, both internal to
`@slidev`:

```
esbuild@0.25.1 invalid: "^0.27.0 || ^0.28.0" from node_modules/@slidev/cli/node_modules/vite,
                                                  node_modules/@slidev/types/node_modules/vite
vite@6.4.3     invalid: "^7.3.0 || ^8.0.0"   from node_modules/@slidev/client/node_modules/vue-router
```

Not introduced here and not addressed here. The 189 `UNMET OPTIONAL DEPENDENCY` lines
(platform-specific binaries) are identical on both sides too.

## Closed as obsolete

**#1565** `bn.js` 4.12.1 → 4.12.5 — `master` already has 4.12.5. It arrived as a transitive of
#1564 (`fast-jwt` / `@fastify/jwt`) in commit `fc96af5`, merged 2026-08-11T16:52:57Z — four
minutes after Dependabot opened #1565 at 16:48:28Z. Confirmed on disk rather than only in the
lockfile: after a clean `npm ci` on `master`, `node_modules/bn.js/package.json` reads `4.12.5`,
there is exactly one copy, and the sole requirer is `asn1.js` at `^4.0.0` (via
`@fastify/jwt` → `fast-jwt`).

Closing it is not just tidying. Unlike #1577 that PR has **both required checks green** and is
`MERGEABLE` — one "re-run failed jobs" click or `@dependabot rebase` would land it — and its
lockfile differs from `master` in **554** path-keyed entries: 119 added, 190 removed, and 245
version changes of which **245 are downgrades and 0 are upgrades** (`@fastify/autoload`
6.5.0 → 6.3.1, the whole `@babel/*` tree, and so on). It would revert a month of merged
Dependabot work to deliver a version the repo already has.

## Left open

**#1577** `typescript` 5.9.2 → 7.0.2 — blocked upstream, evidence above. This PR takes the
compiler as far as it currently goes. Note that this branch is stale in the same direction: it
too would downgrade `@fastify/autoload` 6.5.0 → 6.3.1 if merged as-is, so it will need a rebase
whenever `typescript-eslint` unblocks it.

## Known and accepted, untouched

- `src/step-04-validation/package-lock.json` and `src/step-05-constraints/package-lock.json` are
  committed stubs (`lockfileVersion` 2, zero dependencies) inside what is otherwise an
  `npm workspaces` repo. Pre-existing.
- npm ≥ 11 reports `esbuild` and `multiline-ts` as having unapproved install scripts, on both
  sides. Deliberately **not** addressed: `npm install-scripts approve` mutates `package.json`
  with an `allowScripts` block that would enable those postinstall scripts during CI `npm ci`.
