### PR TITLE
chore(deps): hold typescript at 6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # TypeScript 7 (the native compiler) dropped the JS compiler API that
+    # @typescript-eslint, eslint-plugin-sql and ts-node-dev load via
+    # `require("typescript")`, so `npm ci` and `npm run lint` both break on it.
+    # Remove this once typescript-eslint ships tsgo support. See #1584.
+    ignore:
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Closes #1584

## What

Ignore semver-major `typescript` updates in `.github/dependabot.yml`, so Dependabot stops
reproposing TypeScript 7 every week. No source or dependency changes — `typescript` is already at
`~6.0.3`, the final 6.x stable.

## Why

Dependabot opened #1577 (`typescript` 6.0.3 → 7.0.2) and both CI jobs fail at `npm ci`:

```
While resolving: @typescript-eslint/eslint-plugin@8.67.0
Found: typescript@7.0.2
Could not resolve dependency:
peer typescript@">=4.8.4 <6.1.0" from @typescript-eslint/eslint-plugin@8.67.0
```

This is not a stale peer range a companion bump would fix. TypeScript 7 is the native (Go)
compiler and **removed the JS compiler API** the toolchain depends on:

- `typescript@7.0.2`'s `exports` map has no `.` → `lib/typescript.js`; `.` resolves to
  `./lib/version.cjs` and only `./unstable/*` subpaths are real. `6.0.3` still has
  `main: ./lib/typescript.js`.
- `@typescript-eslint/typescript-estree` and `ts-api-utils` call `require("typescript")`
  unconditionally at module load, so the parser throws under TS 7.
- `eslint.config.js` sets `parser: tsParser` for **all** `**/*.js` and `**/*.ts`, so
  `npm run lint` would break repo-wide, not just for `.ts` files.
- `eslint-plugin-sql` bundles its own nested `@typescript-eslint/*` — same ceiling.
- `ts-node-dev` / `ts-node` need the JS API too, and `src/step-14-typescript` uses both, so
  workshop step 14 would break for attendees.

No published `@typescript-eslint` supports TS 7 — `latest` (8.69.0) and `canary`
(8.69.1-alpha.0) both peer `typescript@">=4.8.4 <6.1.0"`, and there is no 9.x line.

A major-only ignore is sufficient: 6.0.3 is the last 6.x release, so `~6.0.3` is already the top
of the line and there is no 6.1.x to drift into.

`npm run typecheck` and the `deploy` workflow were never at risk — TS 7 ships a native `tsc`, and
`@slidev/cli`/`@slidev/client` depend on `typescript@^6.0.3` directly so slidev nests its own
copy regardless.

#1584 records the unblock condition and the follow-up steps for when tsgo support lands.

## Verification

On this branch, with the unchanged dependency set:

- `npm ci` — resolves with no `ERESOLVE`; `require('typescript').version` → `6.0.3`
- `npm run lint` — exit 0
- `npm run typecheck` — exit 0
- `.github/dependabot.yml` parses as valid YAML with the expected structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
